### PR TITLE
Fix verification error on ART runtime

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1531,8 +1531,8 @@
   {:added "1.0"}
   [x & body]
   `(let [lockee# ~x]
+     (monitor-enter lockee#)
      (try
-      (monitor-enter lockee#)
       ~@body
       (finally
        (monitor-exit lockee#)))))


### PR DESCRIPTION
Move monitor-enter outside try block, if the monitor-enter fails to acquire the lock, we should not attempt to release it.
