### PR TITLE
Fix ART verification errors in NREPL

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -1531,11 +1531,15 @@
   {:added "1.0"}
   [x & body]
   `(let [lockee# ~x]
-     (monitor-enter lockee#)
      (try
-      ~@body
-      (finally
-       (monitor-exit lockee#)))))
+       (monitor-enter lockee#)
+       (try
+         ~@body
+         (finally
+           (try
+            (monitor-exit lockee#)
+            (catch Exception e# (throw (RuntimeException. (str "Failed to release the lock on " lockee#) e#))))))
+       (catch Exception e# (throw (RuntimeException. (str "Could not obtain a lock on " lockee#) e#))))))
 
 (defmacro ..
   "form => fieldName-symbol or (instanceMethodName-symbol args*)


### PR DESCRIPTION
Still awaiting comments on the upstream ticket, but for now this gets rid of the last of the verification errors. The only error with nrepl now appears to be dex2oat complaining about the dex version number.
