### PR TITLE
Removed stale :refer to javadoc

### DIFF
--- a/src/clj/clojure/main.clj
+++ b/src/clj/clojure/main.clj
@@ -161,7 +161,6 @@
 (def ^{:doc "A sequence of lib specs that are applied to `require`
 by default when a new command-line REPL is started."} repl-requires
   '[[clojure.repl :refer (source apropos dir pst doc find-doc)]
-    [clojure.java.javadoc :refer (javadoc)]
     [clojure.pprint :refer (pp pprint)]])
 
 (defmacro with-read-known


### PR DESCRIPTION
Removes this: (harmless) error:

```
$ java -jar ./clojure-1.7.0-r4.jar
Clojure 1.7.0
FileNotFoundException Could not locate clojure/java/javadoc__init.class or clojure/java/javadoc.clj on classpath. clojure.lang.RT.load (RT.java:462)
user=>
```
